### PR TITLE
Update to 2.8.1

### DIFF
--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -47,7 +47,7 @@ modules:
     sources:
       - type: git
         url: https://code.videolan.org/videolan/x264.git
-        commit: 544c61f082194728d0391fb280a6e138ba320a96
+        commit: eaa68fad9e5d201d42fde51665f2d137ae96baf0
 
   - name: 'x265'
     buildsystem: cmake-ninja
@@ -58,8 +58,8 @@ modules:
       - -DENABLE_CLI=OFF
     sources:
       - type: archive
-        url: https://deb.debian.org/debian/pool/main/x/x265/x265_3.4.orig.tar.gz
-        sha256: c2047f23a6b729e5c70280d23223cb61b57bfe4ad4e8f1471eeee2a61d148672
+        url: https://deb.debian.org/debian/pool/main/x/x265/x265_3.5.orig.tar.gz
+        sha256: e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
 
   - name: avidemux
     buildsystem: simple

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -1,7 +1,7 @@
 app-id: org.avidemux.Avidemux
 default-branch: stable
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 command: avidemux3_qt5
 finish-args:

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -68,5 +68,5 @@ modules:
       - cp -R install/app/* /app
     sources:
       - type: archive
-        url: https://github.com/mean00/avidemux2/releases/download/2.8.0/avidemux_2.8.0.tar.gz
-        sha256: d1ec6f5277e51228ecf0ee1ca89fae24c591f520f87ce96fabec8818d04de33b
+        url: https://github.com/mean00/avidemux2/releases/download/2.8.1/avidemux_2.8.1.tar.gz
+        sha256: 77d9bdca8683ce57c192b69d207cfab7cf92a7759ce0f63fa37b5c8e42ad3da2


### PR DESCRIPTION
Update Avidemux to 2.8.1, x265 to 3.5, x264 to the latest commit and the runtime to 22.08.
The 21.08 runtime will likely reach end of life as soon as the freedesktop one does, which is scheduled for 2023/08.