### PR TITLE
Patch: Fix issues with appstreamcli validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder/
+repo/
+*.flatpak

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -78,3 +78,5 @@ modules:
         path: patches/libavcodec-clip-constants.patch
       - type: patch
         path: patches/Force-libdir-location.patch
+      - type: patch
+        path: patches/Fix-issues-with-appstreamcli-validation.patch

--- a/patches/Fix-issues-with-appstreamcli-validation.patch
+++ b/patches/Fix-issues-with-appstreamcli-validation.patch
@@ -1,0 +1,35 @@
+diff --git a/avidemux/qt4/xdg_data/org.avidemux.Avidemux.appdata.xml.in b/avidemux/qt4/xdg_data/org.avidemux.Avidemux.appdata.xml.in
+index f918a5e..b9df760 100644
+--- a/avidemux/qt4/xdg_data/org.avidemux.Avidemux.appdata.xml.in
++++ b/avidemux/qt4/xdg_data/org.avidemux.Avidemux.appdata.xml.in
+@@ -1,9 +1,13 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!-- Copyright 2017 Adrien Vergé -->
+ <component type="desktop">
++    <launchable type="desktop-id">org.avidemux.Avidemux.desktop</launchable>
+     <id>org.avidemux.Avidemux</id>
+     <metadata_license>CC0</metadata_license>
+     <project_license>GPL-2.0+</project_license>
++    <developer id="avidemux.org">
++      <name>Avidemux Team</name>
++    </developer>
+     <name>Avidemux</name>
+     <summary>Multi-purpose video editing and processing software</summary>
+     <description>
+@@ -24,8 +28,14 @@
+     </provides>
+     <update_contact>Avidemux team -- avidemux.org/smif/</update_contact>
+     <screenshots>
+-        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot1.png</screenshot>
+-        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot2.png</screenshot>
++        <screenshot type="default">
++            <image>http://fixounet.free.fr/avidemux/index_files/screenshot1.png</image>
++            <caption>Main Window</caption>
++        </screenshot>
++        <screenshot>
++            <image>http://fixounet.free.fr/avidemux/index_files/screenshot2.png</image>
++            <caption>Media Information Window</caption>
++        </screenshot>
+     </screenshots>
+     <content_rating type="oars-1.1"/>
+     <releases>


### PR DESCRIPTION

This fixes 3 validation errors and 1 "information" message given by `appstreamcli`.

These changes should be upstreamed later.

```
$ appstreamcli --version
AppStream version: 1.0.2
```

Before:

```sh
$ appstreamcli validate builddir/export/share/metainfo/org.avidemux.Avidemux.metainfo.xml
E: org.avidemux.Avidemux:27: screenshot-no-media
E: org.avidemux.Avidemux:28: screenshot-no-media
E: org.avidemux.Avidemux:~: desktop-app-launchable-missing
I: org.avidemux.Avidemux:~: developer-info-missing

✘ Validation failed: errors: 3, infos: 1, pedantic: 3
```

---

After:

```sh
$ appstreamcli validate builddir/export/share/metainfo/org.avidemux.Avidemux.metainfo.xml
I: org.avidemux.Avidemux:32: screenshot-media-url-not-secure
     http://fixounet.free.fr/avidemux/index_files/screenshot1.png
I: org.avidemux.Avidemux:36: screenshot-media-url-not-secure
     http://fixounet.free.fr/avidemux/index_files/screenshot2.png

✔ Validation was successful: infos: 2, pedantic: 1
```

There are still 2 "information" messages remaining to be fixed, but these aren't really critical right now.