### PR TITLE
Patch: Don't manually add an extension when saving a file

### DIFF
--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -80,3 +80,5 @@ modules:
         path: patches/Force-libdir-location.patch
       - type: patch
         path: patches/Fix-issues-with-appstreamcli-validation.patch
+      - type: patch
+        path: patches/Dont-manually-add-extension-when-saving-file.patch

--- a/patches/Dont-manually-add-extension-when-saving-file.patch
+++ b/patches/Dont-manually-add-extension-when-saving-file.patch
@@ -1,0 +1,21 @@
+diff --git a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4_old.cpp b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+index b5a5c79..819029b 100644
+--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4_old.cpp
++++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+@@ -142,16 +142,6 @@ static int fileSelWriteInternal(const char *label, char *target, uint32_t max, c
+     int len = strlen(fileName.toUtf8().constData());
+     if(!len || len >= max) return 0;
+ 
+-    // Check if we need to add an extension....
+-    if(doFilter)
+-    {                     
+-        if(!strstr(fileName.toUtf8().constData(),".")) //FIXME
+-        {
+-            fileName=fileName+QString(".")+QString(ext);
+-            len+=extSize;
+-        }
+-    }
+-
+     if(opts & QFileDialog::DontConfirmOverwrite)
+     {
+         QFile newFile(fileName);


### PR DESCRIPTION
When saving a file, the user can choose not to type a file extension.

In such cases, we can't just manually add a file extension later and expect that writing to this new path will just work, because the FileChooser portal did not allow us to write to this modified path.

Fixes #22