### PR TITLE
Add support for NVENC encoding

### DIFF
--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -57,6 +57,21 @@ modules:
         url: https://deb.debian.org/debian/pool/main/x/x265/x265_3.5.orig.tar.gz
         sha256: e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
 
+  - name: ffnvcodec
+    no-autogen: true
+    make-install-args:
+      - PREFIX=/app
+    sources:
+      - type: git
+        url: https://github.com/FFmpeg/nv-codec-headers.git
+        commit: 43d91706e097565f57b311e567f0219838bcc2f6
+        tag: n11.1.5.3
+        x-checker-data:
+          type: git
+          tag-pattern: ^n([\d.]+)$
+          versions:
+            <: '12'
+
   - name: avidemux
     buildsystem: simple
     build-commands:
@@ -82,3 +97,5 @@ modules:
         path: patches/Fix-issues-with-appstreamcli-validation.patch
       - type: patch
         path: patches/Dont-manually-add-extension-when-saving-file.patch
+      - type: patch
+        path: patches/Find-nvcodec-headers.patch

--- a/patches/Find-nvcodec-headers.patch
+++ b/patches/Find-nvcodec-headers.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/admCheckNvEnc.cmake b/cmake/admCheckNvEnc.cmake
+index 94f9adb..66ad69d 100644
+--- a/cmake/admCheckNvEnc.cmake
++++ b/cmake/admCheckNvEnc.cmake
+@@ -9,7 +9,7 @@ MACRO(checkNvEnc)
+             PKG_CHECK_MODULES(FFNVENC ffnvcodec)
+             IF (FFNVENC_FOUND)
+                 FIND_PATH(NVENC_INCLUDE_DIR nvEncodeAPI.h
+-                        PATHS /usr/local/include/ffnvcodec /usr/include/ffnvcodec /include/ffnvcodec ${FFNVENC_CFLAGS} ${CROSS}/include)
++                        PATHS /usr/local/include/ffnvcodec /usr/include/ffnvcodec /include/ffnvcodec /app/include/ffnvcodec ${FFNVENC_CFLAGS} ${CROSS}/include)
+                 IF (NVENC_INCLUDE_DIR)
+                     MESSAGE(STATUS "NVENC header found in ${NVENC_INCLUDE_DIR}")
+                     SET(USE_NVENC True)


### PR DESCRIPTION
This was tested on a GTX 660 with the 470.239.06 driver, and only H.264 encoding was tested.

The version of the ffnvcodec module is fixed to use the 11.x branch on purpose, so that older NVIDIA GPUs (like the GTX 660) can still benefit from NVENC encoding as well.

Finally, a patch had to be added so that Avidemux could find the ffnvcodec headers.

#### NVENC encoding with Avidemux in action

![nvenc](https://github.com/flathub/org.avidemux.Avidemux/assets/626206/5be8fbf7-d03c-4946-9685-877209a3cfb9)
