### PR TITLE
Force `QT_QPA_PLATFORM=xcb`

### DIFF
--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -6,6 +6,7 @@ command: avidemux3_qt5
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --env=QT_QPA_PLATFORM=xcb
   - --device=dri
   - --socket=pulseaudio
   - --persist=.avidemux6


### PR DESCRIPTION
Without this, Avidemux crashes at start up in some configurations.

The most common scenario is when `QT_QPA_PLATFORM` is (inadvertently?) set to `wayland` on the host: Because we don't expose the Wayland socket, Qt will abort the program when it fails to initialize the QPA plugin for Wayland:

```
$ QT_QPA_PLATFORM=wayland flatpak run org.avidemux.Avidemux
 [UI_Init] 00:08:01-797  Starting Qt5 GUI...
Failed to create wl_display (No such file or directory) qt.qpa.plugin: Could not load the Qt platform plugin "wayland" in "" even though it was found. This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, xcb.
```

This partially reverts commit 81bdf3e8b5703b52e9f578cc31113f27c474a1e7.

Fixes #30
See also: https://github.com/flathub/org.avidemux.Avidemux/issues/29#issuecomment-3080039073 (and follow-up comments)