### PR TITLE
Update KDE runtime to 5.15-25.08

### DIFF
--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -57,17 +57,24 @@ modules:
         url: https://code.videolan.org/videolan/x264.git
         commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
 
-  - name: 'x265'
+  - name: x265
     buildsystem: cmake-ninja
     builddir: true
     subdir: source
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_CLI=OFF
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5 # TODO: investigate removing this on their next release
     sources:
       - type: archive
-        url: https://deb.debian.org/debian/pool/main/x/x265/x265_3.5.orig.tar.gz
-        sha256: e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
+        url: https://bitbucket.org/multicoreware/x265_git/downloads/x265_4.1.tar.gz
+        sha256: a31699c6a89806b74b0151e5e6a7df65de4b49050482fe5ebf8a4379d7af8f29
+        x-checker-data:
+          type: anitya
+          project-id: 7275
+          url-template: https://bitbucket.org/multicoreware/x265_git/downloads/x265_$version.tar.gz
+      - type: patch
+        path: patches/x265-cmake-fix.patch # https://bitbucket.org/multicoreware/x265_git/commits/51ae8e922bcc4586ad4710812072289af91492a8
 
   - name: ffnvcodec
     no-autogen: true
@@ -100,12 +107,10 @@ modules:
         url: https://github.com/mean00/avidemux2/releases/download/2.8.1/avidemux_2.8.1.tar.gz
         sha256: 77d9bdca8683ce57c192b69d207cfab7cf92a7759ce0f63fa37b5c8e42ad3da2
       - type: patch
-        path: patches/Dont-redirect-build-output.patch
-      - type: patch
-        path: patches/libavcodec-clip-constants.patch
-      - type: patch
-        path: patches/Force-libdir-location.patch
-      - type: patch
-        path: patches/Fix-issues-with-appstreamcli-validation.patch
-      - type: patch
-        path: patches/Find-nvcodec-headers.patch
+        paths:
+          - patches/Dont-redirect-build-output.patch
+          - patches/libavcodec-clip-constants.patch
+          - patches/Force-libdir-location.patch
+          - patches/Fix-issues-with-appstreamcli-validation.patch
+          - patches/Find-nvcodec-headers.patch
+          - patches/Fix-build-with-x265-4.1.patch # https://github.com/mean00/avidemux2/commit/c16d32a67cdb012db093472ad3776713939a30d1

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -35,12 +35,18 @@ modules:
           project-id: 5286
           url-template: https://github.com/yasm/yasm/releases/download/v$version/yasm-$version.tar.gz
 
-  - name: xvid
+  - name: xvidcore
     subdir: build/generic
+    build-options:
+      cflags: -std=c17 # TODO: investigate removing this on their next release
     sources:
       - type: archive
         url: https://downloads.xvid.com/downloads/xvidcore-1.3.7.tar.gz
         sha256: abbdcbd39555691dd1c9b4d08f0a031376a3b211652c0d8b3b8aa9be1303ce2d
+        x-checker-data:
+          type: anitya
+          project-id: 14474
+          url-template: https://downloads.xvid.com/downloads/xvidcore-$version.tar.gz
 
   - name: 'x264'
     config-opts:

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -1,8 +1,9 @@
 app-id: org.avidemux.Avidemux
 runtime: org.kde.Platform
-runtime-version: 5.15-24.08
+runtime-version: 5.15-25.08
 sdk: org.kde.Sdk
 command: avidemux3_qt5
+
 finish-args:
   - --share=ipc
   - --socket=x11
@@ -11,12 +12,14 @@ finish-args:
   - --socket=pulseaudio
   - --persist=.avidemux6
   - --filesystem=host
+
 cleanup:
   - /include
   - /lib/pkgconfig
   - /share/man
   - '*.a'
   - '*.la'
+
 modules:
   - shared-modules/glu/glu-9.json
   - shared-modules/glew/glew.json
@@ -93,6 +96,9 @@ modules:
 
   - name: avidemux
     buildsystem: simple
+    build-options:
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5' # TODO: investigate removing this on their next release
     build-commands:
       - bash bootStrap.bash --prefix=/app
       - make -C buildCli install

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -21,15 +21,19 @@ modules:
   - shared-modules/glu/glu-9.json
   - shared-modules/glew/glew.json
 
-  - name: yasm # avidemux still uses yasm
-    buildsystem: cmake-ninja
-    builddir: true
+  - name: yasm
+    build-options:
+      cflags: -std=c17 # TODO: investigate removing this on their next release
     cleanup:
       - '*'
     sources:
       - type: archive
-        url: http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
+        url: https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz
         sha256: 3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f
+        x-checker-data:
+          type: anitya
+          project-id: 5286
+          url-template: https://github.com/yasm/yasm/releases/download/v$version/yasm-$version.tar.gz
 
   - name: xvid
     subdir: build/generic

--- a/org.avidemux.Avidemux.yaml
+++ b/org.avidemux.Avidemux.yaml
@@ -48,14 +48,14 @@ modules:
           project-id: 14474
           url-template: https://downloads.xvid.com/downloads/xvidcore-$version.tar.gz
 
-  - name: 'x264'
+  - name: x264
     config-opts:
       - --disable-cli
       - --enable-shared
     sources:
       - type: git
         url: https://code.videolan.org/videolan/x264.git
-        commit: eaa68fad9e5d201d42fde51665f2d137ae96baf0
+        commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
 
   - name: 'x265'
     buildsystem: cmake-ninja

--- a/patches/Fix-build-with-x265-4.1.patch
+++ b/patches/Fix-build-with-x265-4.1.patch
@@ -1,0 +1,45 @@
+From c16d32a67cdb012db093472ad3776713939a30d1 Mon Sep 17 00:00:00 2001
+From: eumagga0x2a <eumagga0x2a@users.noreply.github.com>
+Date: Sat, 4 Jan 2025 23:34:14 +0100
+Subject: [PATCH] [x265] Fix build with x265 4.1
+
+---
+ .../ADM_videoEncoder/x265/ADM_x265Setup.cpp   | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+index 55816a713..0bc330b6e 100644
+--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
++++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+@@ -216,13 +216,30 @@ bool x265Encoder::setup(void)
+                         {
+                              param.rc.bStatWrite=1;
+                              param.rc.bStatRead=0;
++#if X265_BUILD > 213
++                             if (strlen(logFile) >= X265_MAX_STRING_SIZE)
++                             {
++                                 ADM_error("Logfile filename length %d out of bounds, must be less than %d\n", strlen(logFile), X265_MAX_STRING_SIZE);
++                                 return false;
++                             }
++                             snprintf(param.rc.statFileName, X265_MAX_STRING_SIZE, "%s", logFile);
++#else
+                              param.rc.statFileName=strdup(logFile);
+- 
++#endif
+                         }else
+                         {
+                              param.rc.bStatWrite=0;
+                              param.rc.bStatRead=1;
++#if X265_BUILD > 213
++                             if (strlen(logFile) >= X265_MAX_STRING_SIZE)
++                             {
++                                 ADM_error("Logfile filename length %d out of bounds, must be less than %d\n", strlen(logFile), X265_MAX_STRING_SIZE);
++                                 return false;
++                             }
++                             snprintf(param.rc.statFileName, X265_MAX_STRING_SIZE, "%s", logFile);
++#else
+                              param.rc.statFileName=strdup(logFile);
++#endif
+                              if(!ADM_fileExist(logFile))
+                              {
+                                    ADM_error("Logfile %s does not exist \n",logFile);

--- a/patches/x265-cmake-fix.patch
+++ b/patches/x265-cmake-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 5c6dda9e8..0b10eaee4 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -6,15 +6,9 @@ if(NOT CMAKE_BUILD_TYPE)
+         FORCE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+-if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
+-endif()
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+-if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
+-endif()
+ 
+ project (x265)
+ cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8


### PR DESCRIPTION
Many changes on this one, please see each individual commit for more details.

I've only tested x264 (including NVENC) and x265 encoding, and it seems normal.

Since Avidemux is quite feature rich, it's nearly impossible for me to test everything, so we'll have to wait on user feedback in case something breaks.